### PR TITLE
add support PL2303HXD gpio2/3 and PL2303GC gpio0/1/2/3 and some usage changed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,20 @@ LDFLAGS = $(shell pkg-config --libs libusb-1.0)
 
 PREFIX?=/usr/local
 
-all: pl2303gpio cp2103gpio
+all: pl2303gpio pl2303gcgpio cp2103gpio
 
 OBJS=usb.c main.c
 pl2303gpio: $(OBJS) pl2303.o
+	$(CC) $(CFLAGS) -Wall -Werror -I"../include" -o $(@) $(^) $(LDFLAGS)
+
+pl2303gcgpio: $(OBJS) pl2303gc.o
 	$(CC) $(CFLAGS) -Wall -Werror -I"../include" -o $(@) $(^) $(LDFLAGS)
 
 cp2103gpio: $(OBJS) cp2103.o
 	$(CC) $(CFLAGS) -Wall -Werror -I"../include" -o $(@) $(^) $(LDFLAGS)
 
 clean:
-	-rm pl2303gpio cp2103gpio
+	-rm pl2303gpio pl2303gcgpio cp2103gpio
 
 install: pl2303gpio cp2103gpio
 	cp pl2303gpio $(PREFIX)/bin

--- a/main.c
+++ b/main.c
@@ -39,10 +39,9 @@ static struct option long_options[] =
 	/* These options set a flag. */
 	{"help",    no_argument,             0, 'h'},
 	{"gpio",    required_argument,       0, 'g'},
-	{"in",      optional_argument,       0, 'i'},
+	{"in",      no_argument,             0, 'i'},
 	{"out",     required_argument,       0, 'o'},
 	{"sleep",   required_argument,       0, 's'},
-	{"read",    no_argument,             0, 'r'},
 	{"product", required_argument,       0, 'p'},
 	{"port",    required_argument,       0, 'P'},
 	{"manuf",   required_argument,       0, 'm'},
@@ -62,9 +61,8 @@ void usage(const char *self)
 	       "\t --manuf=blah      - Use device with this 'manufacturer' string\n"
 	       "\t -P/--port  N      - Use only device in physical port N\n"
 	       "\t -g/--gpio  n      - select GPIO, n=0, 1\n"
-	       "\t -i/--in           - configure GPIO as input\n"
+	       "\t -i/--in           - configure GPIO as input and read value\n"
 	       "\t -o/--out v        - configure GPIO as output with value v\n"
-	       "\t -r/--read v       - Read current GPIO value\n\n"
 	       "\t -s/--sleep v      - Delay for v ms\n\n"
 	       "\t -l/--list         - List candidates\n\n"		   
 	       "Examples: \n"
@@ -93,7 +91,7 @@ int main(int argc, char* argv[])
 	while(1) {
 		int option_index = 0;
 
-		c = getopt_long (argc, argv, "hg:i:o:r:s:lP:",
+		c = getopt_long (argc, argv, "hg:io:s:lP:",
 				 long_options, &option_index);
 
 		/* Detect the end of the options. */
@@ -128,9 +126,8 @@ int main(int argc, char* argv[])
 		{
 			int v=0; 
 			check_handle(&h, get_device_vid(), get_device_pid(), manuf, product, serial, port);
-			if (optarg)
-				v = atoi(optarg);
 			gpio_in(h, gpio, v); 
+			printf("%d\n", gpio_read(h, gpio) ? 1 : 0);
 			break;
 		}
 		case 'o':
@@ -146,12 +143,6 @@ int main(int argc, char* argv[])
 		{
 			unsigned long n = atoi(optarg);
 			usleep(n*1000);
-			break;
-		}
-		case 'r': 
-		{
-			check_handle(&h, get_device_vid(), get_device_pid(), manuf, product, serial, port);
-			printf("%d\n", gpio_read(h, gpio) ? 1 : 0); 
 			break;
 		}
 

--- a/pl2303gc.c
+++ b/pl2303gc.c
@@ -1,0 +1,153 @@
+#include <stdio.h>
+#include <stdlib.h>
+/* According to POSIX.1-2001 */
+#include <sys/select.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <termios.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <libusb.h>
+#include <getopt.h>
+
+
+#define _GNU_SOURCE
+#include <getopt.h>
+
+
+#define I_VENDOR_NUM        0x67b
+#define I_PRODUCT_NUM       0x23a3
+
+
+#define VENDOR_READ_REQUEST_TYPE	0xc0
+#define VENDOR_READ_REQUEST		0x81
+
+#define VENDOR_WRITE_REQUEST_TYPE	0x40
+#define VENDOR_WRITE_REQUEST		0x80
+
+struct pl2303_pinctrl{
+	uint16_t reg_read_mask;
+
+	uint16_t dir_reg;
+	uint8_t dir_mask; //out mode: set with mask. input mode: clean with mask
+
+	uint16_t in_reg;
+	uint8_t in_mask;
+
+	uint16_t out_reg;
+	uint8_t out_mask;
+};
+
+
+struct pl2303_pinctrl pins[] = {
+	{0x80, 0x03, 0x01, 0x01, 0x01, 0x01, 0x01},
+	{0x80, 0x03, 0x02, 0x01, 0x02, 0x01, 0x02},
+	{0x80, 0x03, 0x04, 0x01, 0x04, 0x01, 0x04},
+	{0x80, 0x03, 0x08, 0x01, 0x08, 0x01, 0x08},
+};
+
+#define PINS_MAX	(sizeof(pins)/sizeof(*pins))
+
+//internal api
+unsigned char pl2303_read_reg(libusb_device_handle *h, unsigned short reg)
+{
+	unsigned char value;
+	int bytes = libusb_control_transfer(
+		h,             // handle obtained with usb_open()
+		VENDOR_READ_REQUEST_TYPE, // bRequestType
+		VENDOR_READ_REQUEST,      // bRequest
+		reg,           // wValue
+		0,             // wIndex
+		&value,        // pointer to destination buffer
+		1,             // wLength
+		1000
+		);
+	handle_error(bytes);
+	//fprintf(stderr, "read reg[0x%02x] = 0x%02x\n", reg ,value);
+	return value;
+}
+
+
+void pl2303_write_reg(libusb_device_handle *h, unsigned short reg, unsigned char value)
+{
+	int bytes = libusb_control_transfer(
+		h,             // handle obtained with usb_open()
+		VENDOR_WRITE_REQUEST_TYPE, // bRequestType
+		VENDOR_WRITE_REQUEST,      // bRequest
+		reg,           // wValue
+		value,         // wIndex
+		0,             // pointer to destination buffer
+		0,             // wLength
+		1000
+		);
+	//fprintf(stderr, write reg[0x%02x] = 0x%02x\n", reg ,value);
+	handle_error(bytes);
+}
+
+
+//export API
+int get_device_vid()
+{
+	return I_VENDOR_NUM;
+}
+
+int get_device_pid()
+{
+	return I_PRODUCT_NUM;
+}
+
+void gpio_out(libusb_device_handle *h, int gpio, int value)
+{
+	unsigned char reg_value;
+
+	if(0 <= gpio && gpio < PINS_MAX){
+		//direct
+		reg_value = pl2303_read_reg(h, pins[gpio].dir_reg | pins[gpio].reg_read_mask);
+		reg_value |= pins[gpio].dir_mask;
+		pl2303_write_reg(h, pins[gpio].dir_reg, reg_value);
+
+		//out
+		reg_value = pl2303_read_reg(h, pins[gpio].out_reg | pins[gpio].reg_read_mask);
+
+		if(!!value){
+			reg_value |= pins[gpio].out_mask;
+		} else {
+			reg_value &= ~pins[gpio].out_mask;
+		}
+		pl2303_write_reg(h, pins[gpio].out_reg, reg_value);
+	} else {
+		fprintf(stderr, "Error: gpio%d is not support\n", gpio);
+		exit(1);
+	}
+}
+
+void gpio_in(libusb_device_handle *h, int gpio, int pullup)
+{
+	unsigned char reg_value;
+
+	if(0 <= gpio && gpio < PINS_MAX){
+		//direct
+		reg_value = pl2303_read_reg(h, pins[gpio].dir_reg | pins[gpio].reg_read_mask);
+		reg_value &= ~pins[gpio].dir_mask;
+		pl2303_write_reg(h, pins[gpio].dir_reg, reg_value);
+	} else {
+		fprintf(stderr, "Error: gpio%d is not support\n", gpio);
+		exit(1);
+	}
+}
+
+int gpio_read(libusb_device_handle *h, int gpio)
+{
+	unsigned char reg_value;
+
+	if(0 <= gpio && gpio < PINS_MAX){
+		//in
+		reg_value = pl2303_read_reg(h, pins[gpio].in_reg | pins[gpio].reg_read_mask);
+		return !!(reg_value &= pins[gpio].in_mask);
+	} else {
+		fprintf(stderr, "Error: gpio%d is not support\n", gpio);
+		exit(1);
+	}
+}


### PR DESCRIPTION
Read gpio value with -i/--in, not -r.
-r is purged.
-i/--in optional argument is removed.
